### PR TITLE
Optimizations for Resnet50

### DIFF
--- a/src/Transform/ONNX/Combine.cpp
+++ b/src/Transform/ONNX/Combine.cpp
@@ -86,6 +86,7 @@ void ONNXPadConstantValueOp::getCanonicalizationPatterns(
 /// on the ONNXCastOp.
 void ONNXCastOp::getCanonicalizationPatterns(
     OwningRewritePatternList &result, MLIRContext *context) {
+  result.insert<CastPropagationPattern>(context);
   result.insert<CastEliminationPattern>(context);
 }
 

--- a/src/Transform/ONNX/Combine.td
+++ b/src/Transform/ONNX/Combine.td
@@ -75,6 +75,12 @@ def CastEliminationPattern : Pat<
 	(replaceWithValue $arg),
   [(HasSameElementType $arg, $type)]>;
 
+// (onnx.Cast (onnx.Cast(%X, $type2), $type1)) = (onnx.Cast(%X, $type1))
+def CastPropagationPattern : Pat<
+	(ONNXCastOp (ONNXCastOp $arg, $type2), $type1),
+	(ONNXCastOp $arg, $type1)>;
+
+
 // Combine transposes.
 def CreateCombinedTransposedPattern :
    NativeCodeCall<"CombinedTransposePattern($_builder, $0, $1)">;

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -107,7 +107,7 @@ func @cast_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   // CHECK-NEXT: return %arg0 : tensor<2xf32>
 }
 
-//CHECK-LABEL: @cast_propagation(%{{.*}}: tensor<2xf32>) -> tensor<2xf32> {
+//CHECK-LABEL: @cast_propagation(%{{.*}}: tensor<2xf32>) -> tensor<2xi32> {
 func @cast_propagation(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   %0 = "onnx.Cast"(%arg0) {to = 3 : si64} : (tensor<2xf32>) -> tensor<2xi8>
   %1 = "onnx.Cast"(%0) {to = 6 : si64} : (tensor<2xi8>) -> tensor<2xi32>

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -107,6 +107,15 @@ func @cast_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   // CHECK-NEXT: return %arg0 : tensor<2xf32>
 }
 
+//CHECK-LABEL: @cast_propagation(%{{.*}}: tensor<2xf32>) -> tensor<2xf32> {
+func @cast_propagation(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+  %0 = "onnx.Cast"(%arg0) {to = 3 : si64} : (tensor<2xf32>) -> tensor<2xi8>
+  %1 = "onnx.Cast"(%0) {to = 6 : si64} : (tensor<2xi8>) -> tensor<2xi32>
+  return %1 : tensor<2xf32>
+
+  // CHECK-NEXT: return "onnx.Cast"(%arg0) {to = 6 : si64} : (tensor<2xf32>) -> tensor<2xi32>
+}
+
 // -----
 
 func @test_conv_batchnormtestmode_fusion_nobias(%arg0 : tensor<1x3x224x224xf32>) -> tensor<1x64x112x112xf32> {


### PR DESCRIPTION
Redundant cast optimization moved to Groq codebase because it can lead to subtle issues. Only implement distribute for mult optimizations