### PR TITLE
Optimize out MatMulInteger with Zero constants or between two constants & Add/Sub by Zero

### DIFF
--- a/src/Dialect/ONNX/ONNXFoldHelper.cpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.cpp
@@ -342,3 +342,35 @@ bool canConstPropCastIntToInt(Builder &builder, Value constOp, Attribute input, 
 
   return fromElemType.isa<IntegerType>() && toElemType.isa<IntegerType>();
 }
+
+
+bool isConstOfZeros(Builder &builder, Attribute attr) {
+
+  DenseElementsAttr denseAttr = attr.cast<DenseElementsAttr>();
+  mlir::Type constElemType = denseAttr.getType().getElementType();
+  if (constElemType.isa<IntegerType>()) {
+    for (IntegerAttr value : denseAttr.getValues<IntegerAttr>()) {
+      APInt inVal = value.getValue();
+      if (!inVal.isNullValue()) {
+        return false;
+      }
+    }
+  } else if (constElemType.isa<FloatType>()) {
+    for (FloatAttr value : denseAttr.getValues<FloatAttr>()) {
+      APFloat inVal = value.getValue();
+      if (!inVal.isZero()) {
+        return false;
+      }
+    }
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+DenseElementsAttr CreateZerosFromTemplate(Builder &builder, Value templateTensor) {
+  ShapedType shapedType = templateTensor.getType().cast<ShapedType>();
+  DenseElementsAttr resultAttr = DenseElementsAttr::get(shapedType, 0);
+  return resultAttr;
+}

--- a/src/Dialect/ONNX/ONNXFoldHelper.hpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.hpp
@@ -218,3 +218,6 @@ DenseElementsAttr ConstPropCastIntToInt(
 bool canConstPropCastIntToInt(Builder &builder, Value constOp, Attribute input, IntegerAttr to);
 bool isConstOfZeros(Builder &builder, Attribute attr);
 DenseElementsAttr CreateZerosFromTemplate(Builder &builder, Value templateTensor);
+DenseElementsAttr CreateMatMulIntegerOfRankTwoConsts(Builder &builder, Value resultTensor, Attribute lhs, Attribute rhs);
+bool isRankTwo(Builder &builder, Attribute attr);
+

--- a/src/Dialect/ONNX/ONNXFoldHelper.hpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.hpp
@@ -216,3 +216,5 @@ DenseElementsAttr ConstPropSlice(Builder &builder, Value resOperand,
 DenseElementsAttr ConstPropCastIntToInt(
     Builder &builder, Value constOp, Attribute input, IntegerAttr to);
 bool canConstPropCastIntToInt(Builder &builder, Value constOp, Attribute input, IntegerAttr to);
+bool isConstOfZeros(Builder &builder, Attribute attr);
+DenseElementsAttr CreateZerosFromTemplate(Builder &builder, Value templateTensor);

--- a/src/Dialect/ONNX/ONNXFoldHelper.hpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.hpp
@@ -218,5 +218,4 @@ DenseElementsAttr ConstPropCastIntToInt(
 bool canConstPropCastIntToInt(Builder &builder, Value constOp, Attribute input, IntegerAttr to);
 bool isConstOfZeros(Builder &builder, Attribute attr);
 DenseElementsAttr CreateZerosFromTemplate(Builder &builder, Value templateTensor);
-DenseElementsAttr CreateMatMulIntegerOfRankTwoConsts(Builder &builder, Value resultTensor, Attribute lhs, Attribute rhs);
-bool isRankTwo(Builder &builder, Attribute attr);
+DenseElementsAttr CreateMatMulIntegerOfConsts(Builder &builder, Value resultValue, Attribute _lhs, Attribute _rhs);

--- a/src/Dialect/ONNX/ONNXFoldHelper.hpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.hpp
@@ -215,7 +215,10 @@ DenseElementsAttr ConstPropSlice(Builder &builder, Value resOperand,
     Attribute steps);
 DenseElementsAttr ConstPropCastIntToInt(
     Builder &builder, Value constOp, Attribute input, IntegerAttr to);
-bool canConstPropCastIntToInt(Builder &builder, Value constOp, Attribute input, IntegerAttr to);
+bool canConstPropCastIntToInt(
+    Builder &builder, Value constOp, Attribute input, IntegerAttr to);
 bool isConstOfZeros(Builder &builder, Attribute attr);
-DenseElementsAttr CreateZerosFromTemplate(Builder &builder, Value templateTensor);
-DenseElementsAttr CreateMatMulIntegerOfConsts(Builder &builder, Value resultValue, Attribute _lhs, Attribute _rhs);
+DenseElementsAttr CreateZerosFromTemplate(
+    Builder &builder, Value templateTensor);
+DenseElementsAttr CreateMatMulIntegerOfConsts(
+    Builder &builder, Value resultValue, Attribute _lhs, Attribute _rhs);

--- a/src/Dialect/ONNX/ONNXFoldHelper.hpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.hpp
@@ -220,4 +220,3 @@ bool isConstOfZeros(Builder &builder, Attribute attr);
 DenseElementsAttr CreateZerosFromTemplate(Builder &builder, Value templateTensor);
 DenseElementsAttr CreateMatMulIntegerOfRankTwoConsts(Builder &builder, Value resultTensor, Attribute lhs, Attribute rhs);
 bool isRankTwo(Builder &builder, Attribute attr);
-

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -53,9 +53,6 @@ def canConstPropCastIntToInt : Constraint<
 def isConstOfZeros : Constraint<
   CPred<"isConstOfZeros($_builder, $0)">>;
 
-def isRankTwo : Constraint<
-  CPred<"isRankTwo($_builder, $0)">>;
-
 // Usefult code generation invokation.
 def GetNullAttr : NativeCodeCall<"Attribute()">;
 
@@ -89,8 +86,8 @@ def CreateIntToIntCastOfConst :
 def CreateZerosFromTemplate :
   NativeCodeCall<"CreateZerosFromTemplate($_builder, $0)">;
 
-def CreateMatMulIntegerOfRankTwoConsts :
-  NativeCodeCall<"CreateMatMulIntegerOfRankTwoConsts($_builder, $0, $1, $2)">;
+def CreateMatMulIntegerOfConsts :
+  NativeCodeCall<"CreateMatMulIntegerOfConsts($_builder, $0, $1, $2)">;
 
 def ValuesHaveSameType : Constraint<
     CPred<"$0.getType() == "
@@ -265,11 +262,11 @@ def MatMulIntegerOfConsts : Pat<
       (ONNXConstantOp $bss, $bsv)
     ),
     (ONNXConstantOp
-      (GetNullAttr), (CreateMatMulIntegerOfRankTwoConsts $resOp, $av, $bv)
+      (GetNullAttr), (CreateMatMulIntegerOfConsts $resOp, $av, $bv)
     ),
     [
-      (AttributeIsNull:$as), (isRankTwo $av),
-      (AttributeIsNull:$bs), (isRankTwo $bv),
+      (AttributeIsNull:$as),
+      (AttributeIsNull:$bs),
       (AttributeIsNull:$ass), (isConstOfZeros $asv),
       (AttributeIsNull:$bss), (isConstOfZeros $bsv)
     ]

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -92,6 +92,11 @@ def CreateZerosFromTemplate :
 def CreateMatMulIntegerOfRankTwoConsts :
   NativeCodeCall<"CreateMatMulIntegerOfRankTwoConsts($_builder, $0, $1, $2)">;
 
+def ValuesHaveSameType : Constraint<
+    CPred<"$0.getType() == "
+          "$1.getType()">,
+    "ValuesHaveSameType">;
+
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise ADD operations.
@@ -160,6 +165,18 @@ def AddConstProp : Pat<
     // Additional constraints (no sparse)
     [(AttributeIsNull:$s1), (AttributeIsNull:$s2)]>;
 
+def AddByZeroOnRhs : Pat<
+    (ONNXAddOp:$result
+      $a,
+      (ONNXConstantOp $bs, $bv)
+    ),
+    (replaceWithValue $a),
+    [
+      (IsNotAConstant:$a),
+      (AttributeIsNull:$bs), (isConstOfZeros $bv),
+      (ValuesHaveSameType $result, $a)
+    ]>;
+
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise SUB / NEG operations.
@@ -197,8 +214,6 @@ def SqrtofConst :  Pat<
     // To sqrt(c)
     (ONNXConstantOp (GetNullAttr), (CreateSqrtOfConst $constOp, $v)),
     [(AttributeIsNull:$s)]>;
-
-
 
 // Constant Propagation for Cast
 def IntToIntCastofConst :  Pat<

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -53,6 +53,9 @@ def canConstPropCastIntToInt : Constraint<
 def isConstOfZeros : Constraint<
   CPred<"isConstOfZeros($_builder, $0)">>;
 
+def isRankTwo : Constraint<
+  CPred<"isRankTwo($_builder, $0)">>;
+
 // Usefult code generation invokation.
 def GetNullAttr : NativeCodeCall<"Attribute()">;
 
@@ -85,6 +88,9 @@ def CreateIntToIntCastOfConst :
 
 def CreateZerosFromTemplate :
   NativeCodeCall<"CreateZerosFromTemplate($_builder, $0)">;
+
+def CreateMatMulIntegerOfRankTwoConsts :
+  NativeCodeCall<"CreateMatMulIntegerOfRankTwoConsts($_builder, $0, $1, $2)">;
 
 
 //===----------------------------------------------------------------------===//
@@ -231,6 +237,24 @@ def MatMulIntegerZeroOnLhs : Pat<
     ),
     [
       (AttributeIsNull:$as), (isConstOfZeros $av),
+      (AttributeIsNull:$ass), (isConstOfZeros $asv),
+      (AttributeIsNull:$bss), (isConstOfZeros $bsv)
+    ]
+>;
+
+def MatMulIntegerOfConsts : Pat<
+    (ONNXMatMulIntegerOp:$resOp
+      (ONNXConstantOp $as, $av),
+      (ONNXConstantOp $bs, $bv),
+      (ONNXConstantOp $ass, $asv),
+      (ONNXConstantOp $bss, $bsv)
+    ),
+    (ONNXConstantOp
+      (GetNullAttr), (CreateMatMulIntegerOfRankTwoConsts $resOp, $av, $bv)
+    ),
+    [
+      (AttributeIsNull:$as), (isRankTwo $av),
+      (AttributeIsNull:$bs), (isRankTwo $bv),
       (AttributeIsNull:$ass), (isConstOfZeros $asv),
       (AttributeIsNull:$bss), (isConstOfZeros $bsv)
     ]

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -47,35 +47,45 @@ def AttributeIsNull :
     Constraint<CPred<"! ($_self)">,
   "Attribute is null">;
 
+def canConstPropCastIntToInt : Constraint<
+  CPred<"canConstPropCastIntToInt($_builder, $0, $1, $2)">>;
+
+def isConstOfZeros : Constraint<
+  CPred<"isConstOfZeros($_builder, $0)">>;
+
 // Usefult code generation invokation.
 def GetNullAttr : NativeCodeCall<"Attribute()">;
 
 def CreateAddOfTwoConst :
-   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXAddOp>($_builder, $0, $1, $2)">;
+  NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXAddOp>($_builder, $0, $1, $2)">;
 
 def CreateSubOfTwoConst :
-   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXSubOp>($_builder, $0, $1, $2)">;
+  NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXSubOp>($_builder, $0, $1, $2)">;
 
 def CreateNegOfConst :
-   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXNegOp>($_builder, $0, $1)">;
+  NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXNegOp>($_builder, $0, $1)">;
 
 def CreateSqrtOfConst :
-   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXSqrtOp>($_builder, $0, $1)">;
+  NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXSqrtOp>($_builder, $0, $1)">;
 
 def CreateMulOfTwoConst :
-   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXMulOp>($_builder, $0, $1, $2)">;
+  NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXMulOp>($_builder, $0, $1, $2)">;
 
 def CreateDivOfTwoConst :
-   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXDivOp>($_builder, $0, $1, $2)">;
+  NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXDivOp>($_builder, $0, $1, $2)">;
 
 def CreateTransposeOfConst :
-   NativeCodeCall<"ConstPropTranspose($_builder, $0, $1, $2)">;
+  NativeCodeCall<"ConstPropTranspose($_builder, $0, $1, $2)">;
 
 def CreateUnsqueezeOfConst:
-   NativeCodeCall<"ConstPropUnsqueeze($_builder, $0, $1)">;
+  NativeCodeCall<"ConstPropUnsqueeze($_builder, $0, $1)">;
 
 def CreateIntToIntCastOfConst :
-   NativeCodeCall<"ConstPropCastIntToInt($_builder, $0, $1, $2)">;
+  NativeCodeCall<"ConstPropCastIntToInt($_builder, $0, $1, $2)">;
+
+def CreateZerosFromTemplate :
+  NativeCodeCall<"CreateZerosFromTemplate($_builder, $0)">;
+
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise ADD operations.
@@ -182,8 +192,7 @@ def SqrtofConst :  Pat<
     (ONNXConstantOp (GetNullAttr), (CreateSqrtOfConst $constOp, $v)),
     [(AttributeIsNull:$s)]>;
 
-def canConstPropCastIntToInt : Constraint<
-  CPred<"canConstPropCastIntToInt($_builder, $0, $1, $2)">>;
+
 
 // Constant Propagation for Cast
 def IntToIntCastofConst :  Pat<
@@ -192,6 +201,40 @@ def IntToIntCastofConst :  Pat<
     // To cast(c)
     (ONNXConstantOp (GetNullAttr), (CreateIntToIntCastOfConst $constOp, $v, $toType)),
     [(AttributeIsNull:$s), (canConstPropCastIntToInt $constOp, $v, $toType)]>;
+
+def MatMulIntegerZeroOnRhs : Pat<
+    (ONNXMatMulIntegerOp:$resOp
+      $a,
+      (ONNXConstantOp $bs, $bv),
+      (ONNXConstantOp $ass, $asv),
+      (ONNXConstantOp $bss, $bsv)
+    ),
+    (ONNXConstantOp
+      (GetNullAttr), (CreateZerosFromTemplate $resOp)
+    ),
+    [
+      (AttributeIsNull:$bs), (isConstOfZeros $bv),
+      (AttributeIsNull:$ass), (isConstOfZeros $asv),
+      (AttributeIsNull:$bss), (isConstOfZeros $bsv)
+    ]
+>;
+
+def MatMulIntegerZeroOnLhs : Pat<
+    (ONNXMatMulIntegerOp:$resOp
+      (ONNXConstantOp $as, $av),
+      $b,
+      (ONNXConstantOp $ass, $asv),
+      (ONNXConstantOp $bss, $bsv)
+    ),
+    (ONNXConstantOp
+      (GetNullAttr), (CreateZerosFromTemplate $resOp)
+    ),
+    [
+      (AttributeIsNull:$as), (isConstOfZeros $av),
+      (AttributeIsNull:$ass), (isConstOfZeros $asv),
+      (AttributeIsNull:$bss), (isConstOfZeros $bsv)
+    ]
+>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise MUL operations.
@@ -269,6 +312,8 @@ def DivConstProp : Pat<
     (ONNXConstantOp (GetNullAttr), (CreateDivOfTwoConst $mulOp, $v1, $v2)),
     // Division constraints (no sparse)
     [(AttributeIsNull:$s1), (AttributeIsNull:$s2)]>;
+
+
 
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
# Original
Optimizations for efficient processing of decomposed QLinearMatMul. 


## Quantization Math / Transforms

[Here](https://arxiv.org/pdf/1712.05877.pdf)'s a good paper with quantized `MatMul` math. But to summarize:


Given `R3 = MatMul(R1, R2)` where `R1`, `R2` and `R3` are high-precision fp tensors, This is how you get `Q3` given `Q1` and `Q2`, where `Q1`, `Q2` and `Q3` are quantized versions of `R1`, `R2` and `R3` respectively:

```
R3 = z3 + m * MatMul(Q1 - z1, Q2 - z2)
```

where `m = s1 * s2 / s3`, and `s?` and `z?` are the scales and zero-points of `Q?`.

`Q1 - z1` and `Q2 - z2` terms need to be `int8` as inputs to `MatMul` and might overflow/underflow. Therefore, we further transform the decomposition using the distributve property of MatMul:

```
R3 = z3 + m * (MatMul(q1, q2) - MatMul(q1, Z2) - MatMul(Z1, q2) + MatMul(Z1, Z2))
```
, where the tensor formats after simplification are:
```
q1: <M, K, i8>
Z2: <K, 1, i8> # broadcasted from z2. Pre-simplification form would be <K, N, i8> but that gets boring...go figure
Z1: <1, K, i8> # broadcasted from z1. Pre-simplification form would be <M, N, i8> but that gets boring...go figure
q2: <K, N, i8>
```
The tensor format of the matmul chain would look like:
```
<M, N, i32> - <M, 1, i32> - <1, N, i32> + <1, 1, i32>
```
ONNX Binary ops would broadcast all four terms into `<M, N, i32>`

## Motivation
Without constant propagation, we'd be computing four `MatMul`s. In reality, `Z1`, `Z2` and `q2` (weights) are oftentimes known at compile time, and we'd theoretically only need one `MatMul` at runtime. Furthermore, if weights are quantized symmetrically, `Z2` would be a `0` tensor, further push the `q1Z2` MatMul to compile time, leaving only one `MatMul` at runtime. This is a pretty good speed improvement!

# Effects

Before const-prop
```
// %arg0: q1 (activation)
// %0: q2 (weight)
// %4: Z1 (activation zero point - non-zero, asymmetric activation)
// %8: Z2 (weight zero point - set to 0 due to symmetrization)
// %20: m, a.k.a s1*s2/s3 (scaling factor)
// %24: z3 (result shift)
module {
  func @main_graph(%arg0: tensor<64x2048xi8>) -> tensor<64x1000xi8> attributes {input_names = ["input.1"], output_names = ["495"]} {
    %0 = "onnx.Constant"() {value = dense<11> : tensor<2048x1000xi8>} : () -> tensor<2048x1000xi8>
    %1 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %2 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<64x2048xi8>, tensor<2048x1000xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<64x1000xi32>
    %4 = "onnx.Constant"() {value = dense<128> : tensor<1x2048xui8>} : () -> tensor<1x2048xui8>
    %5 = "onnx.Constant"() {value = dense<0> : tensor<1xui8>} : () -> tensor<1xui8>
    %6 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %7 = "onnx.MatMulInteger"(%4, %0, %5, %6) : (tensor<1x2048xui8>, tensor<2048x1000xi8>, tensor<1xui8>, tensor<1xi8>) -> tensor<1x1000xi32>
    %8 = "onnx.Constant"() {value = dense<0> : tensor<2048x1xi8>} : () -> tensor<2048x1xi8>
    %9 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %10 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %11 = "onnx.MatMulInteger"(%arg0, %8, %9, %10) : (tensor<64x2048xi8>, tensor<2048x1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<64x1xi32>
    %12 = "onnx.Constant"() {value = dense<128> : tensor<1x2048xui8>} : () -> tensor<1x2048xui8>
    %13 = "onnx.Constant"() {value = dense<0> : tensor<2048x1xi8>} : () -> tensor<2048x1xi8>
    %14 = "onnx.Constant"() {value = dense<0> : tensor<1xui8>} : () -> tensor<1xui8>
    %15 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %16 = "onnx.MatMulInteger"(%12, %13, %14, %15) : (tensor<1x2048xui8>, tensor<2048x1xi8>, tensor<1xui8>, tensor<1xi8>) -> tensor<1x1xi32>
    %17 = "onnx.Sub"(%3, %11) : (tensor<64x1000xi32>, tensor<64x1xi32>) -> tensor<64x1000xi32>
    %18 = "onnx.Sub"(%7, %16) : (tensor<1x1000xi32>, tensor<1x1xi32>) -> tensor<1x1000xi32>
    %19 = "onnx.Sub"(%17, %18) : (tensor<64x1000xi32>, tensor<1x1000xi32>) -> tensor<64x1000xi32>
    %20 = "onnx.Constant"() {value = dense<0.00157479628> : tensor<f32>} : () -> tensor<f32>
    %21 = "onnx.Cast"(%19) {to = 1 : si64} : (tensor<64x1000xi32>) -> tensor<64x1000xf32>
    %22 = "onnx.Mul"(%21, %20) : (tensor<64x1000xf32>, tensor<f32>) -> tensor<64x1000xf32>
    %23 = "onnx.Cast"(%22) {to = 6 : si64} : (tensor<64x1000xf32>) -> tensor<64x1000xi32>
    %24 = "onnx.Constant"() {value = dense<-128> : tensor<i32>} : () -> tensor<i32>
    %25 = "onnx.Add"(%23, %24) : (tensor<64x1000xi32>, tensor<i32>) -> tensor<64x1000xi32>
    %26 = "onnx.Cast"(%25) {to = 3 : si64} : (tensor<64x1000xi32>) -> tensor<64x1000xi8>
    return %26 : tensor<64x1000xi8>
  }
  "onnx.EntryPoint"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32} : () -> ()
}

```

after const-prop
```
module {
  func @main_graph(%arg0: tensor<64x2048xi8>) -> tensor<64x1000xi8> attributes {input_names = ["input.1"], output_names = ["495"]} {
    %0 = "onnx.Constant"() {value = dense<11> : tensor<2048x1000xi8>} : () -> tensor<2048x1000xi8>
    %1 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %2 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<64x2048xi8>, tensor<2048x1000xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<64x1000xi32>
    %4 = "onnx.Constant"() {value = dense<2883584> : tensor<64x1000xi32>} : () -> tensor<64x1000xi32>
    %5 = "onnx.Add"(%3, %4) : (tensor<64x1000xi32>, tensor<64x1000xi32>) -> tensor<64x1000xi32>
    %6 = "onnx.Constant"() {value = dense<0.00157479628> : tensor<f32>} : () -> tensor<f32>
    %7 = "onnx.Cast"(%5) {to = 1 : si64} : (tensor<64x1000xi32>) -> tensor<64x1000xf32>
    %8 = "onnx.Mul"(%7, %6) : (tensor<64x1000xf32>, tensor<f32>) -> tensor<64x1000xf32>
    %9 = "onnx.Cast"(%8) {to = 6 : si64} : (tensor<64x1000xf32>) -> tensor<64x1000xi32>
    %10 = "onnx.Constant"() {value = dense<-128> : tensor<i32>} : () -> tensor<i32>
    %11 = "onnx.Add"(%9, %10) : (tensor<64x1000xi32>, tensor<i32>) -> tensor<64x1000xi32>
    %12 = "onnx.Cast"(%11) {to = 3 : si64} : (tensor<64x1000xi32>) -> tensor<64x1000xi8>
    return %12 : tensor<64x1000xi8>
  }
  "onnx.EntryPoint"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32} : () -> ()
}
```

# Update: Rank > 2
Added support for upper-rank broadcasting. 

Before const-prop:
```
module {
  func @main_graph() -> tensor<20x5x2x1xi32> attributes {input_names = ["input.1"], output_names = ["495"]} {
    %12 = "onnx.Constant"() {value = dense<1> : tensor<20x5x2x3xi8>} : () -> tensor<20x5x2x3xi8>
    %13 = "onnx.Constant"() {value = dense<1> : tensor<5x3x1xi8>} : () -> tensor<5x3x1xi8>
    %14 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %15 = "onnx.Constant"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
    %16 = "onnx.MatMulInteger"(%12, %13, %14, %15) : (tensor<20x5x2x3xi8>, tensor<5x3x1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<20x5x2x1xi32>
    return %16 : tensor<20x5x2x1xi32>
  }
  "onnx.EntryPoint"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32} : () -> ()
}
```
After:
```
module {
  func @main_graph() -> tensor<20x5x2x1xi32> attributes {input_names = ["input.1"], output_names = ["495"]} {
    %0 = "onnx.Constant"() {value = dense<3> : tensor<20x5x2x1xi32>} : () -> tensor<20x5x2x1xi32>
    return %0 : tensor<20x5x2x1xi32>
  }
  "onnx.EntryPoint"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32} : () -> ()
}
```
