### PR TITLE
Fix integer cast const-prop bug

### DIFF
--- a/src/Dialect/ONNX/ONNXFoldHelper.cpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.cpp
@@ -315,7 +315,8 @@ DenseElementsAttr ConstPropCastIntToInt(
   IntegerType toElemType = mlir::UnrankedTensorType::get(
       convertONNXTypeToMLIRType(
           builder, static_cast<onnx::TensorProto_DataType>(toAttr)))
-                        .getElementType().cast<IntegerType>();
+                               .getElementType()
+                               .cast<IntegerType>();
 
   assert(fromElemType.isa<IntegerType>() && toElemType.isa<IntegerType>());
 


### PR DESCRIPTION
Fixing my own bug introduced in https://github.com/thebyrd/onnx-mlir/pull/15. Zero extension should be used when either input or output is unsigned. Previously, we only check if output is unsigned. The old algorithm would use sign extension inappropriately and cause this:

```
Input: 128 : ui8
Output: -128: i32
```
Because `0x80` gets extended to `0xFF80`