### PR TITLE
[Groq#8294] constant prop for split

### DIFF
--- a/src/Dialect/ONNX/ONNXFoldHelper.hpp
+++ b/src/Dialect/ONNX/ONNXFoldHelper.hpp
@@ -222,3 +222,20 @@ DenseElementsAttr CreateZerosFromTemplate(
     Builder &builder, Value templateTensor);
 DenseElementsAttr CreateMatMulIntegerOfConsts(
     Builder &builder, Value resultValue, Attribute _lhs, Attribute _rhs);
+
+DenseElementsAttr ConstPropCastFloatToFloat(
+    Builder &builder, Value constOp, Attribute input, IntegerAttr to);
+bool canConstPropCastFloatToFloat(
+    Builder &builder, Value constOp, Attribute input, IntegerAttr to);
+
+// const prop for split changes
+mlir::RankedTensorType constructRankedTensorType(mlir::ShapedType type);
+
+void RecurseConstPropSplit(PatternRewriter &rewriter,
+    std::vector<Attribute> &resVector, DenseElementsAttr attr,
+    SmallVector<uint64_t, 4> &indices, uint64_t splitAxis, uint64_t axisOffset,
+    uint64_t axisSize, int freeRank);
+
+DenseElementsAttr ConstPropSplit(PatternRewriter &rewriter, Value resOperand,
+    Attribute attr, IntegerAttr axisAttr, ArrayAttr splitAttr,
+    unsigned resIndex);

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -419,7 +419,6 @@ void registerDialects(mlir::MLIRContext &context) {
 
 void addONNXToMLIRPasses(mlir::PassManager &pm) {
   pm.addPass(mlir::createDecomposeONNXToONNXPass());
-  pm.addPass(mlir::createConstPropONNXToONNXPass());
   pm.addPass(mlir::createShapeInferencePass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createAttributePromotionPass());

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -28,11 +28,68 @@ using namespace mlir;
 namespace {
 
 //===----------------------------------------------------------------------===//
+// Code to perform constant propagation for split.
+//===----------------------------------------------------------------------===//
+
+class ConstPropSplitPattern : public OpRewritePattern<ONNXSplitOp> {
+public:
+  using OpRewritePattern<ONNXSplitOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXSplitOp op, PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    // A dense attribute that contains constant values of the split op's input.
+    Attribute denseAttr;
+
+    // Match
+    ONNXSplitOp *splitOp = ::llvm::dyn_cast_or_null<::mlir::ONNXSplitOp>(&op);
+    {
+      Operation *producerOp = splitOp->input().getDefiningOp();
+      ONNXConstantOp castedProducerOp =
+          ::llvm::dyn_cast_or_null<::mlir::ONNXConstantOp>(producerOp);
+      if (!castedProducerOp)
+        return failure();
+      // Check whether the constant op is using a dense value or not.
+      Attribute sparseAttr =
+          producerOp->getAttrOfType<::mlir::Attribute>("sparse_value");
+      if (sparseAttr)
+        return rewriter.notifyMatchFailure(op, [&](::mlir::Diagnostic &diag) {
+          diag << "entities '' failed to satisfy constraint: Attribute "
+                  "is null";
+        });
+      Attribute dataAttr =
+          producerOp->getAttrOfType<::mlir::Attribute>("value");
+      denseAttr = dataAttr;
+    }
+
+    // Rewrite
+    unsigned outputNum = splitOp->getNumResults();
+    int64_t rank = splitOp->input().getType().cast<ShapedType>().getRank();
+    IntegerAttr axisAttr = splitOp->axisAttr();
+    ArrayAttr splitAttr = splitOp->splitAttr();
+
+    SmallVector<::mlir::Value, 4> returnValues;
+    for (int i = 0; i < outputNum; ++i) {
+      Value splitOutput = splitOp->getResults()[i];
+      Value constOp =
+          rewriter.create<ONNXConstantOp>(loc, splitOutput.getType(),
+              /*sparse_value=*/Attribute(),
+              /*dense_value=*/
+              ConstPropSplit(
+                  rewriter, splitOutput, denseAttr, axisAttr, splitAttr, i));
+      returnValues.emplace_back(constOp);
+    }
+
+    rewriter.replaceOp(op, returnValues);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pattern definition.
 //===----------------------------------------------------------------------===//
 
 #include "src/Transform/ONNX/ONNXConstProp.inc"
-
 //===----------------------------------------------------------------------===//
 // Code to manage the pass.
 //===----------------------------------------------------------------------===//
@@ -52,6 +109,7 @@ void ConstPropONNXToONNXPass::runOnFunction() {
 
   OwningRewritePatternList patterns;
   populateWithGenerated(context, patterns);
+  patterns.insert<ConstPropSplitPattern>(&getContext());
 
   applyPatternsAndFoldGreedily(function, patterns);
 } // end anonymous namespace

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -50,6 +50,9 @@ def AttributeIsNull :
 def canConstPropCastIntToInt : Constraint<
   CPred<"canConstPropCastIntToInt($_builder, $0, $1, $2)">>;
 
+def canConstPropCastFloatToFloat : Constraint<
+  CPred<"canConstPropCastFloatToFloat($_builder, $0, $1, $2)">>;
+
 def isConstOfZeros : Constraint<
   CPred<"isConstOfZeros($_builder, $0)">>;
 
@@ -82,6 +85,9 @@ def CreateUnsqueezeOfConst:
 
 def CreateIntToIntCastOfConst :
   NativeCodeCall<"ConstPropCastIntToInt($_builder, $0, $1, $2)">;
+
+def CreateFloatToFloatCastOfConst :
+  NativeCodeCall<"ConstPropCastFloatToFloat($_builder, $0, $1, $2)">;
 
 def CreateZerosFromTemplate :
   NativeCodeCall<"CreateZerosFromTemplate($_builder, $0)">;
@@ -219,6 +225,14 @@ def IntToIntCastofConst :  Pat<
     // To cast(c)
     (ONNXConstantOp (GetNullAttr), (CreateIntToIntCastOfConst $constOp, $v, $toType)),
     [(AttributeIsNull:$s), (canConstPropCastIntToInt $constOp, $v, $toType)]>;
+
+// Constant Propagation for Cast (float to float)
+def FloatToFloatCastofConst :  Pat<
+    // From  onnx.Cast(c)
+    (ONNXCastOp (ONNXConstantOp:$constOp $s, $v), $toType),
+    // To cast(c)
+    (ONNXConstantOp (GetNullAttr), (CreateFloatToFloatCastOfConst $constOp, $v, $toType)),
+    [(AttributeIsNull:$s), (canConstPropCastFloatToFloat $constOp, $v, $toType)]>;
 
 def MatMulIntegerZeroOnRhs : Pat<
     (ONNXMatMulIntegerOp:$resOp


### PR DESCRIPTION
 - added support for split const prop
   (needed for the LSTM rewriter)
 - code picked from original onnx-mlir repo
   (commit: 4ffadba05a810729fb16982917c119117d5dd5e1)